### PR TITLE
Sync image list and improve overlay loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.local
 .DS_Store
 Thumbs.db
+/.claude

--- a/src/ui/single-page/navigation.ts
+++ b/src/ui/single-page/navigation.ts
@@ -1,4 +1,5 @@
 import { store } from '../../state/store';
+import { qa } from '../../utils/dom';
 
 export interface NavigationDeps {
   overlay: HTMLElement;
@@ -13,9 +14,25 @@ export function setupNavigation(deps: NavigationDeps): {
   nextImage: () => void;
   previousImage: () => void;
 } {
+  function hasLoadingPlaceholders(): boolean {
+    return document.querySelectorAll('.r-ph').length > 0;
+  }
+
+  function syncAllImages(): void {
+    const freshImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+    if (freshImages.length !== store.allImages.length) {
+      store.allImages = freshImages;
+    }
+  }
+
   function nextImage(): void {
+    syncAllImages();
+
     if (store.currentImageIndex < store.allImages.length - 1) {
       store.currentImageIndex++;
+      deps.updateImage();
+      deps.checkAndLoadNextPage();
+    } else if (hasLoadingPlaceholders()) {
       deps.updateImage();
       deps.checkAndLoadNextPage();
     } else {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         },
         namespace: 'http://tampermonkey.net/',
         homepageURL: 'https://github.com/Leovikii/e-hentai-plus',
-        version: '2.2.0',
+        version: '2.2.1',
         description: {
           '': 'Infinite scroll & reader mode with image prefetch and floating controls for E-Hentai / ExHentai',
           'zh-CN': '为 E-Hentai / ExHentai 提供无限滚动和阅读模式，支持图片预取与悬浮控制',


### PR DESCRIPTION
Keep store.allImages in sync with DOM and improve single-page overlay loading/observer behavior. Add qa import and helper functions (hasLoadingPlaceholders, syncAllImages); ensure nextImage syncs images and handles loading placeholders. During image load polling, refresh image list and update scrollbar. Refine MutationObserver to detect expected total, extend safety timeout to 30s and perform a final image sync on timeout. Also bump extension version to 2.2.1 and add /.claude to .gitignore.