### PR TITLE
Add back-to-top button and jumpTo API

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ import { registerMenuCommands } from './menu-commands';
     close: () => spmHandle.close(),
     isActive: () => spmHandle.isActive(),
     getOverlayElement: () => spmHandle.getOverlayElement(),
+    jumpTo: (index: number) => spmHandle.jumpTo(index),
   });
 
   spmHandle = initSinglePageMode();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,4 +18,5 @@ export interface SinglePageModeHandle {
   close: () => void;
   isActive: () => boolean;
   getOverlayElement: () => HTMLElement;
+  jumpTo: (index: number) => void;
 }

--- a/src/ui/float-control.ts
+++ b/src/ui/float-control.ts
@@ -1,5 +1,5 @@
 import { store } from '../state/store';
-import { svgReader, svgPlay, svgPause, svgSettings } from '../utils/icons';
+import { svgReader, svgPlay, svgPause, svgSettings, svgTop } from '../utils/icons';
 import { createSettingsPanel } from './settings-panel';
 import type { SinglePageModeHandle } from '../types';
 
@@ -25,7 +25,8 @@ export function createFloatControl(spmHandle: SinglePageModeHandle): void {
   circleControl.className = 'circle-control';
   circleControl.innerHTML = svgReader;
   circleControl.title = 'Reader Mode';
-  circleControl.onclick = () => {
+  circleControl.onclick = (e) => {
+    if (e.target !== circleControl && !circleControl.querySelector('svg')?.contains(e.target as Node)) return;
     if (spmHandle.isActive()) {
       spmHandle.close();
       autoPlayBtn.classList.add('hidden');
@@ -45,7 +46,22 @@ export function createFloatControl(spmHandle: SinglePageModeHandle): void {
   settingsBtn.innerHTML = svgSettings;
   settingsBtn.title = 'Settings';
 
-  // Assemble horizontally: [play] [circle] [settings]
+  // Back to top button (above the control bar)
+  const topBtn = document.createElement('div');
+  topBtn.className = 'side-btn top-btn';
+  topBtn.innerHTML = svgTop;
+  topBtn.title = 'Back to Top';
+  topBtn.onclick = (e) => {
+    e.stopPropagation();
+    if (spmHandle.isActive()) {
+      spmHandle.jumpTo(0);
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  // Assemble horizontally: [play] [circle] [settings], with top button above circle
+  circleControl.appendChild(topBtn);
   floatControl.appendChild(autoPlayBtn);
   floatControl.appendChild(circleControl);
   floatControl.appendChild(settingsBtn);

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -244,10 +244,18 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     }
   }
 
+  function jumpTo(index: number): void {
+    if (!overlay.classList.contains('active')) return;
+    store.currentImageIndex = Math.max(0, Math.min(index, store.allImages.length - 1));
+    updateImage();
+    autoPlay.reset();
+  }
+
   return {
     open,
     close,
     isActive: () => overlay.classList.contains('active'),
     getOverlayElement: () => overlay,
+    jumpTo,
   };
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -12,8 +12,13 @@ html, body { background-color: #111 !important; color: #ccc !important; margin: 
 .retry-btn:hover { background: #555; }
 
 /* Float control — horizontal: [play] [circle] [settings] */
-.float-control { position: fixed; right: 30px; bottom: 30px; z-index: 9999; display: flex; flex-direction: row; align-items: center; gap: 0; transition: opacity 0.3s; }
+.float-control { position: fixed; right: 30px; bottom: 30px; z-index: 9999; display: flex; flex-direction: row; align-items: center; gap: 0; transition: opacity 0.3s; -webkit-user-select: none; user-select: none; }
 .float-control.hidden { opacity: 0; pointer-events: none; }
+
+/* Top button (above the circle control) */
+.side-btn.top-btn { position: absolute; bottom: calc(100% + 10px); left: 50%; transform: translateX(-50%); opacity: 0.3; pointer-events: auto; }
+.float-control:hover .side-btn.top-btn { opacity: 0.8; }
+.side-btn.top-btn:hover { opacity: 1 !important; background: #555; transform: translateX(-50%) scale(1.1); }
 
 /* Side buttons (play & settings) */
 .side-btn { width: 36px; height: 36px; background: #333; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.3s; opacity: 0; pointer-events: none; }
@@ -25,7 +30,7 @@ html, body { background-color: #111 !important; color: #ccc !important; margin: 
 .auto-play-btn.hidden { display: none; }
 
 /* Circle control — reader mode button */
-.circle-control { width: 50px; height: 50px; background: #1a1a1a; border: 2px solid #555; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.3s; box-shadow: 0 4px 12px rgba(0,0,0,0.5); margin: 0 6px; }
+.circle-control { position: relative; width: 50px; height: 50px; background: #1a1a1a; border: 2px solid #555; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: all 0.3s; box-shadow: 0 4px 12px rgba(0,0,0,0.5); margin: 0 6px; }
 .circle-control:hover { border-color: #888; box-shadow: 0 6px 16px rgba(0,0,0,0.7); transform: scale(1.05); }
 .circle-control svg { width: 24px; height: 24px; fill: #fff; }
 

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -7,3 +7,5 @@ export const svgReader = `<svg viewBox="0 0 24 24"><path d="M21 5c-1.11-.35-2.33
 export const svgPlay = `<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>`;
 
 export const svgPause = `<svg viewBox="0 0 24 24"><path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z"/></svg>`;
+
+export const svgTop = `<svg viewBox="0 0 24 24"><path d="M4 4h16v2H4V4zm4 8l1.41 1.41L11 11.83V22h2V11.83l1.59 1.58L16 12l-4-4-4 4z"/></svg>`;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         },
         namespace: 'http://tampermonkey.net/',
         homepageURL: 'https://github.com/Leovikii/e-hentai-plus',
-        version: '2.2.1',
+        version: '2.2.2',
         description: {
           '': 'Infinite scroll & reader mode with image prefetch and floating controls for E-Hentai / ExHentai',
           'zh-CN': '为 E-Hentai / ExHentai 提供无限滚动和阅读模式，支持图片预取与悬浮控制',


### PR DESCRIPTION
Introduce a Back-to-Top control and expose a jumpTo API for single-page reader mode. Changes: add svgTop icon and styles for the top button; add topBtn to the float control (click scrolls to top or calls spmHandle.jumpTo(0) when reader is active) and guard circle click handling; extend SinglePageModeHandle with jumpTo and implement it in the overlay (updates currentImageIndex and resets autoplay); expose jumpTo from main.ts. Also bump package version to 2.2.2.