### PR TITLE
V2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "e-hentai-plus",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scroll-mode.ts
+++ b/src/features/scroll-mode.ts
@@ -20,7 +20,9 @@ function setErrorState(
 }
 
 export function processBatch(links: string[], pIndex: number): void {
-  const mainBox = document.querySelector('#gdt') as HTMLElement;
+  const container = store.settings.scrollMode
+    ? document.querySelector('#gdt') as HTMLElement
+    : document.querySelector('#gdt-hidden') as HTMLElement;
   const batchDiv = document.createElement('div');
   batchDiv.className = 'page-batch';
   const fragment = document.createDocumentFragment();
@@ -57,7 +59,7 @@ export function processBatch(links: string[], pIndex: number): void {
   });
 
   batchDiv.appendChild(fragment);
-  mainBox.appendChild(batchDiv);
+  container.appendChild(batchDiv);
 }
 
 export function setupAutoScroll(): void {

--- a/src/features/scroll-mode.ts
+++ b/src/features/scroll-mode.ts
@@ -19,7 +19,7 @@ function setErrorState(
   retryBtn.onclick = createRetryHandler(url, placeholder, pIndex, index);
 }
 
-export function processBatch(links: string[], pIndex: number): void {
+export function processBatch(links: string[], pIndex: number, prepend = false): void {
   const container = store.settings.scrollMode
     ? document.querySelector('#gdt') as HTMLElement
     : document.querySelector('#gdt-hidden') as HTMLElement;
@@ -59,7 +59,11 @@ export function processBatch(links: string[], pIndex: number): void {
   });
 
   batchDiv.appendChild(fragment);
-  container.appendChild(batchDiv);
+  if (prepend && container.firstChild) {
+    container.insertBefore(batchDiv, container.firstChild);
+  } else {
+    container.appendChild(batchDiv);
+  }
 }
 
 export function setupAutoScroll(): void {

--- a/src/features/single-page-mode.ts
+++ b/src/features/single-page-mode.ts
@@ -1,7 +1,7 @@
 import { store } from '../state/store';
 import { createSinglePageOverlay } from '../ui/single-page/overlay';
 import { processBatch } from './scroll-mode';
-import { getNextUrl } from '../services/page-parser';
+import { getNextUrl, getPrevUrl } from '../services/page-parser';
 import type { SinglePageModeHandle } from '../types';
 
 export function initSinglePageMode(): SinglePageModeHandle {
@@ -10,6 +10,10 @@ export function initSinglePageMode(): SinglePageModeHandle {
       store.currPage++;
       processBatch(links, store.currPage);
       store.nextUrl = getNextUrl(doc);
+    },
+    onLoadPrevPage: (links, doc) => {
+      processBatch(links, store.currPage - 1, true);
+      store.prevUrl = getPrevUrl(doc);
     },
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import './ui/styles.css';
 import { store } from './state/store';
 import { qa } from './utils/dom';
 import { hideOriginalElements } from './utils/dom';
-import { calcTotal, getNextUrl } from './services/page-parser';
+import { calcTotal, getNextUrl, getPrevUrl, parseImageRange } from './services/page-parser';
 import { setupPrefetchListener } from './services/prefetch';
 import { processBatch, setupAutoScroll } from './features/scroll-mode';
 import { initSinglePageMode } from './features/single-page-mode';
@@ -33,6 +33,7 @@ import { registerMenuCommands } from './menu-commands';
   }
 
   store.nextUrl = getNextUrl(document);
+  store.prevUrl = getPrevUrl(document);
 
   if (store.settings.scrollMode) {
     // Scroll mode: replace original page with custom scroll view
@@ -44,6 +45,10 @@ import { registerMenuCommands } from './menu-commands';
     setupPrefetchListener();
   } else {
     // No scroll mode: keep original page, load images into hidden container for reader mode
+    const range = parseImageRange(document);
+    if (range) {
+      store.imageOffset = range.start - 1; // Convert 1-based to 0-based
+    }
     const hiddenBox = document.createElement('div');
     hiddenBox.id = 'gdt-hidden';
     hiddenBox.style.display = 'none';

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { registerMenuCommands } from './menu-commands';
   store.currPage = urlP ? parseInt(urlP) + 1 : 1;
 
   const initLinks = Array.from(qa('#gdt a', document)).map(a => (a as HTMLAnchorElement).href);
+  store.perPage = initLinks.length || 20;
 
   const galleryId = window.location.pathname;
   const savedTotal = localStorage.getItem(`eh_total_${galleryId}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,6 @@ import { createFloatControl } from './ui/float-control';
 import { registerMenuCommands } from './menu-commands';
 
 (function main() {
-  hideOriginalElements();
-
   const mainBox = document.querySelector('#gdt') as HTMLElement;
   if (!mainBox) return;
 
@@ -35,9 +33,22 @@ import { registerMenuCommands } from './menu-commands';
 
   store.nextUrl = getNextUrl(document);
 
-  // Clear original content and load first batch
-  mainBox.innerHTML = '';
-  processBatch(initLinks, store.currPage);
+  if (store.settings.scrollMode) {
+    // Scroll mode: replace original page with custom scroll view
+    document.documentElement.classList.add('scroll-mode');
+    hideOriginalElements();
+    mainBox.innerHTML = '';
+    processBatch(initLinks, store.currPage);
+    setupAutoScroll();
+    setupPrefetchListener();
+  } else {
+    // No scroll mode: keep original page, load images into hidden container for reader mode
+    const hiddenBox = document.createElement('div');
+    hiddenBox.id = 'gdt-hidden';
+    hiddenBox.style.display = 'none';
+    document.body.appendChild(hiddenBox);
+    processBatch(initLinks, store.currPage);
+  }
 
   // Initialize single page mode with lazy wrapper for circular dependency
   let spmHandle: ReturnType<typeof initSinglePageMode>;
@@ -51,12 +62,6 @@ import { registerMenuCommands } from './menu-commands';
   });
 
   spmHandle = initSinglePageMode();
-
-  // Auto scroll (IntersectionObserver)
-  setupAutoScroll();
-
-  // Prefetch
-  setupPrefetchListener();
 
   // Menu commands
   registerMenuCommands();

--- a/src/menu-commands.ts
+++ b/src/menu-commands.ts
@@ -2,6 +2,12 @@ import { GM_registerMenuCommand } from '$';
 import { store } from './state/store';
 
 export function registerMenuCommands(): void {
+  GM_registerMenuCommand('Toggle Scroll Mode', () => {
+    store.updateSetting('scrollMode', !store.settings.scrollMode);
+    alert(`Scroll Mode ${store.settings.scrollMode ? 'Enabled' : 'Disabled'}`);
+    location.reload();
+  });
+
   GM_registerMenuCommand('Toggle Auto Scroll', () => {
     store.updateSetting('autoScroll', !store.settings.autoScroll);
     alert(`Auto Scroll ${store.settings.autoScroll ? 'Enabled' : 'Disabled'}`);

--- a/src/services/image-loader.ts
+++ b/src/services/image-loader.ts
@@ -1,11 +1,16 @@
 import { q } from '../utils/dom';
 import { CFG } from '../state/config';
+import { requestQueue } from './request-queue';
 
 const parser = new DOMParser();
+const imageCache = new Map<string, string>();
 
-export async function loadImageWithRetry(url: string, retries = 0): Promise<string | null> {
+async function fetchImageSrc(url: string, retries = 0): Promise<string | null> {
   try {
     const response = await fetch(url);
+    if (response.status === 429 || response.status === 503) {
+      throw { rateLimited: true };
+    }
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const html = await response.text();
     const doc = parser.parseFromString(html, 'text/html');
@@ -13,13 +18,27 @@ export async function loadImageWithRetry(url: string, retries = 0): Promise<stri
     const imgSrc = imgEl?.src;
     if (!imgSrc) throw new Error('Image not found');
     return imgSrc;
-  } catch {
+  } catch (err) {
     if (retries < CFG.maxRetries) {
-      await new Promise(resolve => setTimeout(resolve, CFG.retryDelay));
-      return loadImageWithRetry(url, retries + 1);
+      const isRateLimited = err && typeof err === 'object' && 'rateLimited' in err;
+      const delay = isRateLimited
+        ? 5000
+        : CFG.retryDelay * Math.pow(2, retries);
+      await new Promise(resolve => setTimeout(resolve, delay));
+      return fetchImageSrc(url, retries + 1);
     }
     return null;
   }
+}
+
+export function loadImageWithRetry(url: string): Promise<string | null> {
+  const cached = imageCache.get(url);
+  if (cached) return Promise.resolve(cached);
+
+  return requestQueue.enqueue(() => fetchImageSrc(url)).then(src => {
+    if (src) imageCache.set(url, src);
+    return src;
+  });
 }
 
 export function createRetryHandler(
@@ -31,6 +50,7 @@ export function createRetryHandler(
   return () => {
     placeholder.className = 'r-ph loading';
     placeholder.textContent = `P${pIndex}-${index + 1} Reloading...`;
+    imageCache.delete(url);
     loadImageWithRetry(url).then(newSrc => {
       if (newSrc) {
         const newImg = document.createElement('img');

--- a/src/services/image-loader.ts
+++ b/src/services/image-loader.ts
@@ -41,6 +41,10 @@ export function loadImageWithRetry(url: string): Promise<string | null> {
   });
 }
 
+export function clearCachedImage(url: string): void {
+  imageCache.delete(url);
+}
+
 export function createRetryHandler(
   url: string,
   placeholder: HTMLElement,

--- a/src/services/page-parser.ts
+++ b/src/services/page-parser.ts
@@ -4,9 +4,9 @@ export function calcTotal(doc: Document, fallbackLinkCount: number): number {
   const gpc = q('.gpc', doc);
   if (gpc) {
     const txt = gpc.textContent ?? '';
-    const m = txt.match(/of\s+(\d+)\s+images/);
+    const m = txt.match(/of\s+([\d,]+)\s+images/);
     if (m && m[1]) {
-      const totalImgs = parseInt(m[1]);
+      const totalImgs = parseInt(m[1].replace(/,/g, ''));
       const perPage = fallbackLinkCount || 20;
       return Math.ceil(totalImgs / perPage);
     }

--- a/src/services/page-parser.ts
+++ b/src/services/page-parser.ts
@@ -20,9 +20,28 @@ export function calcTotal(doc: Document, fallbackLinkCount: number): number {
   return 1;
 }
 
+export function parseImageRange(doc: Document): { start: number; total: number } | null {
+  const gpc = q('.gpc', doc);
+  if (!gpc) return null;
+  const txt = gpc.textContent ?? '';
+  const m = txt.match(/Showing\s+([\d,]+)\s*-\s*([\d,]+)\s+of\s+([\d,]+)/);
+  if (!m) return null;
+  return {
+    start: parseInt(m[1].replace(/,/g, '')),
+    total: parseInt(m[3].replace(/,/g, '')),
+  };
+}
+
 export function getNextUrl(doc: Document): string | null {
   const ptt = q('.ptt', doc);
   if (!ptt) return null;
   const nextBtn = Array.from(qa('td a', ptt)).find(a => (a.textContent ?? '').includes('>'));
   return nextBtn ? (nextBtn as HTMLAnchorElement).href : null;
+}
+
+export function getPrevUrl(doc: Document): string | null {
+  const ptt = q('.ptt', doc);
+  if (!ptt) return null;
+  const prevBtn = Array.from(qa('td a', ptt)).find(a => (a.textContent ?? '').includes('<'));
+  return prevBtn ? (prevBtn as HTMLAnchorElement).href : null;
 }

--- a/src/services/request-queue.ts
+++ b/src/services/request-queue.ts
@@ -18,19 +18,19 @@ class RequestQueue {
   }
 
   private run(): void {
-    if (this.running >= CFG.maxConcurrent || this.queue.length === 0) return;
+    while (this.running < CFG.maxConcurrent && this.queue.length > 0) {
+      const task = this.queue.shift()!;
+      this.running++;
 
-    const task = this.queue.shift()!;
-    this.running++;
+      const next = () => {
+        this.running--;
+        setTimeout(() => this.run(), CFG.requestSpacing);
+      };
 
-    const next = () => {
-      this.running--;
-      setTimeout(() => this.run(), CFG.requestSpacing);
-    };
-
-    task.execute()
-      .then(value => { task.resolve(value); next(); })
-      .catch(reason => { task.reject(reason); next(); });
+      task.execute()
+        .then(value => { task.resolve(value); next(); })
+        .catch(reason => { task.reject(reason); next(); });
+    }
   }
 }
 

--- a/src/services/request-queue.ts
+++ b/src/services/request-queue.ts
@@ -1,0 +1,37 @@
+import { CFG } from '../state/config';
+
+type Task<T> = {
+  execute: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+class RequestQueue {
+  private queue: Task<unknown>[] = [];
+  private running = 0;
+
+  enqueue<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({ execute: task, resolve, reject } as Task<unknown>);
+      this.run();
+    });
+  }
+
+  private run(): void {
+    if (this.running >= CFG.maxConcurrent || this.queue.length === 0) return;
+
+    const task = this.queue.shift()!;
+    this.running++;
+
+    const next = () => {
+      this.running--;
+      setTimeout(() => this.run(), CFG.requestSpacing);
+    };
+
+    task.execute()
+      .then(value => { task.resolve(value); next(); })
+      .catch(reason => { task.reject(reason); next(); });
+  }
+}
+
+export const requestQueue = new RequestQueue();

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -8,7 +8,7 @@ export const CFG: AppConfig = {
   retryDelay: 1000,
   maxConcurrent: 3,
   requestSpacing: 100,
-  imageLoadTimeout: 10000,
+  imageLoadTimeout: 8000,
 };
 
 export function loadSettings(): UserSettings {

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -13,7 +13,6 @@ export function loadSettings(): UserSettings {
     autoScroll: GM_getValue('autoScroll', true),
     showControl: GM_getValue('showControl', true),
     autoEnterSinglePage: GM_getValue('autoEnterSinglePage', false),
-    autoPlay: GM_getValue('autoPlay', false),
     autoPlayInterval: GM_getValue('autoPlayInterval', 3000),
   };
 }

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -10,6 +10,7 @@ export const CFG: AppConfig = {
 
 export function loadSettings(): UserSettings {
   return {
+    scrollMode: GM_getValue('scrollMode', true),
     autoScroll: GM_getValue('autoScroll', true),
     showControl: GM_getValue('showControl', true),
     autoEnterSinglePage: GM_getValue('autoEnterSinglePage', false),

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -6,6 +6,8 @@ export const CFG: AppConfig = {
   prefetchDistance: 5000,
   maxRetries: 3,
   retryDelay: 1000,
+  maxConcurrent: 3,
+  requestSpacing: 100,
 };
 
 export function loadSettings(): UserSettings {

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -8,6 +8,7 @@ export const CFG: AppConfig = {
   retryDelay: 1000,
   maxConcurrent: 3,
   requestSpacing: 100,
+  imageLoadTimeout: 10000,
 };
 
 export function loadSettings(): UserSettings {

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -12,6 +12,7 @@ class Store {
   // Page state
   currPage = 1;
   totalPage = 1;
+  perPage = 20;
   nextUrl: string | null = null;
   isFetching = false;
   nextPagePrefetched = false;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -13,7 +13,9 @@ class Store {
   currPage = 1;
   totalPage = 1;
   perPage = 20;
+  imageOffset = 0;  // Global index of first loaded image (0-based)
   nextUrl: string | null = null;
+  prevUrl: string | null = null;
   isFetching = false;
   nextPagePrefetched = false;
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,7 +2,7 @@ import { GM_setValue } from '$';
 import type { UserSettings } from '../types';
 import { loadSettings } from './config';
 
-type StoreEvent = 'settingsChanged';
+type StoreEvent = 'settingsChanged' | 'readerModeChanged';
 type Listener = () => void;
 
 class Store {
@@ -20,6 +20,7 @@ class Store {
   currentImageIndex = 0;
   allImages: HTMLImageElement[] = [];
   autoPlayTimer: ReturnType<typeof setInterval> | null = null;
+  autoPlay = false;  // Session-only, not persisted
 
   constructor() {
     this._settings = loadSettings();
@@ -42,7 +43,7 @@ class Store {
     this.listeners.get(event)!.add(listener);
   }
 
-  private emit(event: StoreEvent): void {
+  emit(event: StoreEvent): void {
     this.listeners.get(event)?.forEach(fn => fn());
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,6 @@ export interface UserSettings {
   autoScroll: boolean;
   showControl: boolean;
   autoEnterSinglePage: boolean;
-  autoPlay: boolean;
   autoPlayInterval: number;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export interface UserSettings {
+  scrollMode: boolean;
   autoScroll: boolean;
   showControl: boolean;
   autoEnterSinglePage: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface AppConfig {
   retryDelay: number;
   maxConcurrent: number;
   requestSpacing: number;
+  imageLoadTimeout: number;
 }
 
 export interface SinglePageModeHandle {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,8 @@ export interface AppConfig {
   prefetchDistance: number;
   maxRetries: number;
   retryDelay: number;
+  maxConcurrent: number;
+  requestSpacing: number;
 }
 
 export interface SinglePageModeHandle {

--- a/src/ui/float-control.ts
+++ b/src/ui/float-control.ts
@@ -9,13 +9,14 @@ export function createFloatControl(spmHandle: SinglePageModeHandle): void {
 
   // Auto-play button (left, hidden until reader mode opens)
   const autoPlayBtn = document.createElement('div');
-  autoPlayBtn.className = `side-btn auto-play-btn hidden${store.settings.autoPlay ? ' active' : ''}`;
-  autoPlayBtn.innerHTML = store.settings.autoPlay ? svgPause : svgPlay;
+  autoPlayBtn.className = `side-btn auto-play-btn hidden${store.autoPlay ? ' active' : ''}`;
+  autoPlayBtn.innerHTML = store.autoPlay ? svgPause : svgPlay;
   autoPlayBtn.title = 'Auto Play';
   autoPlayBtn.onclick = (e) => {
     e.stopPropagation();
-    const newValue = !store.settings.autoPlay;
-    store.updateSetting('autoPlay', newValue);
+    const newValue = !store.autoPlay;
+    store.autoPlay = newValue;
+    store.emit('settingsChanged');
     autoPlayBtn.innerHTML = newValue ? svgPause : svgPlay;
     autoPlayBtn.classList.toggle('active', newValue);
   };
@@ -29,15 +30,21 @@ export function createFloatControl(spmHandle: SinglePageModeHandle): void {
     if (e.target !== circleControl && !circleControl.querySelector('svg')?.contains(e.target as Node)) return;
     if (spmHandle.isActive()) {
       spmHandle.close();
-      autoPlayBtn.classList.add('hidden');
     } else {
       spmHandle.open();
-      autoPlayBtn.classList.remove('hidden');
-      // Sync button state with current autoPlay setting
-      autoPlayBtn.innerHTML = store.settings.autoPlay ? svgPause : svgPlay;
-      autoPlayBtn.classList.toggle('active', store.settings.autoPlay);
     }
   };
+
+  // Sync play button visibility with reader mode state (works for both manual and auto-enter)
+  store.on('readerModeChanged', () => {
+    if (spmHandle.isActive()) {
+      autoPlayBtn.classList.remove('hidden');
+      autoPlayBtn.innerHTML = store.autoPlay ? svgPause : svgPlay;
+      autoPlayBtn.classList.toggle('active', store.autoPlay);
+    } else {
+      autoPlayBtn.classList.add('hidden');
+    }
+  });
 
   // Settings button (right)
   const settings = createSettingsPanel();

--- a/src/ui/settings-panel.ts
+++ b/src/ui/settings-panel.ts
@@ -7,10 +7,11 @@ export interface SettingsPanelHandle {
 
 interface SettingItem {
   label: string;
-  key: keyof Pick<typeof store.settings, 'showControl' | 'autoScroll' | 'autoEnterSinglePage'>;
+  key: keyof Pick<typeof store.settings, 'scrollMode' | 'showControl' | 'autoScroll' | 'autoEnterSinglePage'>;
 }
 
 const SETTINGS: SettingItem[] = [
+  { label: 'Scroll Mode', key: 'scrollMode' },
   { label: 'Show Control', key: 'showControl' },
   { label: 'Auto Scroll', key: 'autoScroll' },
   { label: 'Auto Enter Reader', key: 'autoEnterSinglePage' },

--- a/src/ui/single-page/auto-play.ts
+++ b/src/ui/single-page/auto-play.ts
@@ -10,7 +10,7 @@ export interface AutoPlayHandle {
 export function createAutoPlay(nextImageFn: () => void): AutoPlayHandle {
   function start(): void {
     if (store.autoPlayTimer) clearInterval(store.autoPlayTimer);
-    if (store.settings.autoPlay) {
+    if (store.autoPlay) {
       store.autoPlayTimer = setInterval(nextImageFn, store.settings.autoPlayInterval);
     }
   }
@@ -23,14 +23,15 @@ export function createAutoPlay(nextImageFn: () => void): AutoPlayHandle {
   }
 
   function reset(): void {
-    if (store.settings.autoPlay) {
+    if (store.autoPlay) {
       stop();
       start();
     }
   }
 
   function stopAtEnd(): void {
-    store.updateSetting('autoPlay', false);
+    store.autoPlay = false;
+    store.emit('settingsChanged');
     stop();
   }
 

--- a/src/ui/single-page/navigation.ts
+++ b/src/ui/single-page/navigation.ts
@@ -40,7 +40,7 @@ export function setupNavigation(deps: NavigationDeps): {
       deps.checkAndLoadNextPage();
     } else {
       deps.checkAndLoadNextPage();
-      if (store.settings.autoPlay) {
+      if (store.autoPlay) {
         deps.stopAutoPlayAtEnd();
       }
     }
@@ -50,7 +50,7 @@ export function setupNavigation(deps: NavigationDeps): {
     if (store.currentImageIndex > 0) {
       store.currentImageIndex--;
       deps.updateImage();
-      if (store.settings.autoPlay) {
+      if (store.autoPlay) {
         deps.resetAutoPlay();
       }
     }

--- a/src/ui/single-page/navigation.ts
+++ b/src/ui/single-page/navigation.ts
@@ -5,6 +5,7 @@ export interface NavigationDeps {
   overlay: HTMLElement;
   updateImage: () => void;
   checkAndLoadNextPage: () => void;
+  checkAndLoadPrevPage: () => void;
   resetAutoPlay: () => void;
   stopAutoPlayAtEnd: () => void;
   closeSinglePageMode: () => void;
@@ -53,6 +54,9 @@ export function setupNavigation(deps: NavigationDeps): {
       if (store.autoPlay) {
         deps.resetAutoPlay();
       }
+    }
+    if (store.currentImageIndex <= 3) {
+      deps.checkAndLoadPrevPage();
     }
   }
 

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -109,7 +109,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
 
   function syncImages(): void {
     const freshImages = Array.from(qa('.r-img')) as HTMLImageElement[];
-    if (freshImages.length !== store.allImages.length) {
+    if (freshImages.length !== store.allImages.length || freshImages.some((img, i) => img !== store.allImages[i])) {
       store.allImages = freshImages;
       scrollbar.update();
     }
@@ -230,15 +230,10 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
       loadObserver.observe(mainBox, { childList: true, subtree: true });
     }
 
-    // Fallback poll — also re-syncs DOM references
+    // Fallback poll for cached images that don't fire load
     loadPollTimer = setInterval(() => {
       if (store.currentImageIndex !== idx) { clearLoadPoll(); return; }
-      // Re-sync in case DOM changed without MutationObserver catching it
-      const freshImages = Array.from(qa('.r-img')) as HTMLImageElement[];
-      if (freshImages.length !== store.allImages.length) {
-        store.allImages = freshImages;
-        scrollbar.update();
-      }
+      // Check if the image reference changed (DOM swap not caught by observer)
       const currentImg = store.allImages[idx];
       if (currentImg && currentImg !== lastKnownImg) {
         lastKnownImg = currentImg;

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -1,6 +1,6 @@
 import { store } from '../../state/store';
 import { qa, isImageReady, fetchPageLinks } from '../../utils/dom';
-import { getNextUrl } from '../../services/page-parser';
+import { getNextUrl, getPrevUrl } from '../../services/page-parser';
 import { createScrollbar } from './scrollbar';
 import { setupNavigation } from './navigation';
 import { createAutoPlay } from './auto-play';
@@ -8,6 +8,7 @@ import type { SinglePageModeHandle } from '../../types';
 
 export interface OverlayDeps {
   onLoadNextPage: (links: string[], doc: Document) => void;
+  onLoadPrevPage: (links: string[], doc: Document) => void;
 }
 
 export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle {
@@ -46,7 +47,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
 
     const ph = document.createElement('div');
     ph.className = 'sp-placeholder';
-    ph.innerHTML = `<div class="sp-placeholder-pulse"></div><div class="sp-placeholder-text">${store.currentImageIndex + 1} / ${store.allImages.length}</div>`;
+    ph.innerHTML = `<div class="sp-placeholder-pulse"></div><div class="sp-placeholder-text">${store.imageOffset + store.currentImageIndex + 1} / ${store.imageOffset + store.allImages.length}</div>`;
     imageContainer.appendChild(ph);
   }
 
@@ -136,12 +137,13 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     store.currentImageIndex = index;
     updateImage();
     autoPlay.reset();
-  }, () => loadNextPage());
+  }, () => loadNextPage(), () => loadPrevPage());
 
   const nav = setupNavigation({
     overlay,
     updateImage,
     checkAndLoadNextPage: () => checkAndLoadNextPage(),
+    checkAndLoadPrevPage: () => loadPrevPage(),
     resetAutoPlay: () => autoPlay.reset(),
     stopAutoPlayAtEnd: () => autoPlay.stopAtEnd(),
     closeSinglePageMode: () => close(),
@@ -162,27 +164,32 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
       return;
     }
 
-    const viewportCenter = window.scrollY + window.innerHeight / 2;
-    const searchRange = window.innerHeight * 2;
+    let startIndex = 0;
 
-    let closestIndex = 0;
-    let minDistance = Infinity;
+    if (store.settings.scrollMode) {
+      const viewportCenter = window.scrollY + window.innerHeight / 2;
+      const searchRange = window.innerHeight * 2;
+      let minDistance = Infinity;
 
-    store.allImages.forEach((img, index) => {
-      const rect = img.getBoundingClientRect();
-      const imgTop = rect.top + window.scrollY;
+      store.allImages.forEach((img, index) => {
+        const rect = img.getBoundingClientRect();
+        const imgTop = rect.top + window.scrollY;
 
-      if (Math.abs(imgTop - viewportCenter) < searchRange) {
-        const imgCenter = imgTop + rect.height / 2;
-        const distance = Math.abs(imgCenter - viewportCenter);
-        if (distance < minDistance) {
-          minDistance = distance;
-          closestIndex = index;
+        if (Math.abs(imgTop - viewportCenter) < searchRange) {
+          const imgCenter = imgTop + rect.height / 2;
+          const distance = Math.abs(imgCenter - viewportCenter);
+          if (distance < minDistance) {
+            minDistance = distance;
+            startIndex = index;
+          }
         }
-      }
-    });
+      });
+    } else {
+      // Non-scroll mode: start at first image of current page (index 0 in allImages)
+      startIndex = 0;
+    }
 
-    store.currentImageIndex = closestIndex;
+    store.currentImageIndex = startIndex;
     overlay.classList.add('active');
     document.body.style.overflow = 'hidden';
     updateImage();
@@ -213,7 +220,8 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
       }
     } else {
       // Navigate to the page containing the current image
-      const targetPage = Math.floor(store.currentImageIndex / store.perPage);
+      const globalIndex = store.imageOffset + store.currentImageIndex;
+      const targetPage = Math.floor(globalIndex / store.perPage);
       const url = new URL(window.location.href);
       const currentPage = parseInt(url.searchParams.get('p') || '0');
       if (targetPage !== currentPage) {
@@ -271,6 +279,55 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
       store.nextPagePrefetched = false;
     }).catch((err) => {
       console.error('[Single Page] Load failed', err);
+      store.isFetching = false;
+    });
+  }
+
+  function loadPrevPage(): void {
+    if (!store.prevUrl || store.isFetching || store.imageOffset <= 0) return;
+
+    store.isFetching = true;
+
+    fetchPageLinks(store.prevUrl).then(({ doc, links }) => {
+      const prevCount = links.length;
+
+      deps.onLoadPrevPage(links, doc);
+
+      const mainBox = document.querySelector(store.settings.scrollMode ? '#gdt' : '#gdt-hidden');
+      if (mainBox) {
+        const expectedTotal = store.allImages.length + prevCount;
+        const obs = new MutationObserver(() => {
+          const newImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+          if (newImages.length !== store.allImages.length) {
+            // Adjust currentImageIndex to account for prepended images
+            const added = newImages.length - store.allImages.length;
+            store.currentImageIndex += added;
+            store.imageOffset -= added;
+            store.allImages = newImages;
+            scrollbar.update();
+          }
+          if (newImages.length >= expectedTotal) {
+            obs.disconnect();
+          }
+        });
+        obs.observe(mainBox, { childList: true, subtree: true });
+        setTimeout(() => {
+          obs.disconnect();
+          const finalImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+          if (finalImages.length !== store.allImages.length) {
+            const added = finalImages.length - store.allImages.length;
+            store.currentImageIndex += added;
+            store.imageOffset -= added;
+            store.allImages = finalImages;
+            scrollbar.update();
+          }
+        }, 30000);
+      }
+
+      store.prevUrl = getPrevUrl(doc);
+      store.isFetching = false;
+    }).catch((err) => {
+      console.error('[Single Page] Load prev failed', err);
       store.isFetching = false;
     });
   }

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -136,7 +136,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     store.currentImageIndex = index;
     updateImage();
     autoPlay.reset();
-  });
+  }, () => loadNextPage());
 
   const nav = setupNavigation({
     overlay,
@@ -233,48 +233,54 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     }
   });
 
+  function loadNextPage(): void {
+    if (!store.nextUrl || store.isFetching) return;
+
+    store.isFetching = true;
+
+    fetchPageLinks(store.nextUrl).then(({ doc, links }) => {
+
+      deps.onLoadNextPage(links, doc);
+
+      const mainBox = document.querySelector(store.settings.scrollMode ? '#gdt' : '#gdt-hidden');
+      if (mainBox) {
+        const expectedTotal = store.allImages.length + links.length;
+        const obs = new MutationObserver(() => {
+          const newImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+          if (newImages.length !== store.allImages.length) {
+            store.allImages = newImages;
+            scrollbar.update();
+          }
+          if (newImages.length >= expectedTotal) {
+            obs.disconnect();
+          }
+        });
+        obs.observe(mainBox, { childList: true, subtree: true });
+        setTimeout(() => {
+          obs.disconnect();
+          const finalImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+          if (finalImages.length !== store.allImages.length) {
+            store.allImages = finalImages;
+            scrollbar.update();
+          }
+        }, 30000);
+      }
+
+      store.nextUrl = getNextUrl(doc);
+      store.isFetching = false;
+      store.nextPagePrefetched = false;
+    }).catch((err) => {
+      console.error('[Single Page] Load failed', err);
+      store.isFetching = false;
+    });
+  }
+
   function checkAndLoadNextPage(): void {
     if (!store.nextUrl || store.isFetching) return;
 
     const remainingImages = store.allImages.length - store.currentImageIndex;
     if (remainingImages <= 10) {
-      store.isFetching = true;
-
-      fetchPageLinks(store.nextUrl).then(({ doc, links }) => {
-
-        deps.onLoadNextPage(links, doc);
-
-        const mainBox = document.querySelector(store.settings.scrollMode ? '#gdt' : '#gdt-hidden');
-        if (mainBox) {
-          const expectedTotal = store.allImages.length + links.length;
-          const obs = new MutationObserver(() => {
-            const newImages = Array.from(qa('.r-img')) as HTMLImageElement[];
-            if (newImages.length !== store.allImages.length) {
-              store.allImages = newImages;
-              scrollbar.update();
-            }
-            if (newImages.length >= expectedTotal) {
-              obs.disconnect();
-            }
-          });
-          obs.observe(mainBox, { childList: true, subtree: true });
-          setTimeout(() => {
-            obs.disconnect();
-            const finalImages = Array.from(qa('.r-img')) as HTMLImageElement[];
-            if (finalImages.length !== store.allImages.length) {
-              store.allImages = finalImages;
-              scrollbar.update();
-            }
-          }, 30000);
-        }
-
-        store.nextUrl = getNextUrl(doc);
-        store.isFetching = false;
-        store.nextPagePrefetched = false;
-      }).catch((err) => {
-        console.error('[Single Page] Load failed', err);
-        store.isFetching = false;
-      });
+      loadNextPage();
     }
   }
 

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -103,7 +103,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     }
 
     // Watch for new images appearing in DOM (auto-scroll adding pages)
-    const mainBox = document.querySelector('#gdt');
+    const mainBox = document.querySelector(store.settings.scrollMode ? '#gdt' : '#gdt-hidden');
     if (mainBox) {
       loadObserver = new MutationObserver(() => {
         if (store.currentImageIndex !== idx) { clearLoadPoll(); return; }
@@ -201,13 +201,15 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     document.body.style.overflow = '';
     store.emit('readerModeChanged');
 
-    const currentImages = Array.from(qa('.r-img')) as HTMLImageElement[];
-    if (store.currentImageIndex >= 0 && store.currentImageIndex < currentImages.length) {
-      const targetImg = currentImages[store.currentImageIndex];
-      if (targetImg) {
-        setTimeout(() => {
-          targetImg.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }, 100);
+    if (store.settings.scrollMode) {
+      const currentImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+      if (store.currentImageIndex >= 0 && store.currentImageIndex < currentImages.length) {
+        const targetImg = currentImages[store.currentImageIndex];
+        if (targetImg) {
+          setTimeout(() => {
+            targetImg.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }, 100);
+        }
       }
     }
   }
@@ -223,7 +225,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
   });
 
   function checkAndLoadNextPage(): void {
-    if (!store.settings.autoScroll || !store.nextUrl || store.isFetching) return;
+    if (!store.nextUrl || store.isFetching) return;
 
     const remainingImages = store.allImages.length - store.currentImageIndex;
     if (remainingImages <= 10) {
@@ -233,7 +235,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
 
         deps.onLoadNextPage(links, doc);
 
-        const mainBox = document.querySelector('#gdt');
+        const mainBox = document.querySelector(store.settings.scrollMode ? '#gdt' : '#gdt-hidden');
         if (mainBox) {
           const expectedTotal = store.allImages.length + links.length;
           const obs = new MutationObserver(() => {

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -211,6 +211,15 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
           }, 100);
         }
       }
+    } else {
+      // Navigate to the page containing the current image
+      const targetPage = Math.floor(store.currentImageIndex / store.perPage);
+      const url = new URL(window.location.href);
+      const currentPage = parseInt(url.searchParams.get('p') || '0');
+      if (targetPage !== currentPage) {
+        url.searchParams.set('p', String(targetPage));
+        window.location.href = url.toString();
+      }
     }
   }
 

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -92,7 +92,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
         removePlaceholder();
         currentImage.src = img.src;
         scrollbar.update();
-        if (wasAutoPlaying && store.settings.autoPlay) autoPlay.start();
+        if (wasAutoPlaying && store.autoPlay) autoPlay.start();
       }
     }
 
@@ -186,8 +186,9 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     overlay.classList.add('active');
     document.body.style.overflow = 'hidden';
     updateImage();
+    store.emit('readerModeChanged');
 
-    if (store.settings.autoPlay) {
+    if (store.autoPlay) {
       autoPlay.start();
     }
   }
@@ -195,8 +196,10 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
   function close(): void {
     clearLoadPoll();
     autoPlay.stop();
+    store.autoPlay = false;
     overlay.classList.remove('active');
     document.body.style.overflow = '';
+    store.emit('readerModeChanged');
 
     const currentImages = Array.from(qa('.r-img')) as HTMLImageElement[];
     if (store.currentImageIndex >= 0 && store.currentImageIndex < currentImages.length) {
@@ -212,7 +215,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
   // Listen for autoPlay setting changes from float-control button
   store.on('settingsChanged', () => {
     if (!overlay.classList.contains('active')) return;
-    if (store.settings.autoPlay) {
+    if (store.autoPlay) {
       autoPlay.start();
     } else {
       autoPlay.stop();

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -1,4 +1,5 @@
 import { store } from '../../state/store';
+import { CFG } from '../../state/config';
 import { qa, isImageReady, fetchPageLinks } from '../../utils/dom';
 import { getNextUrl, getPrevUrl } from '../../services/page-parser';
 import { createScrollbar } from './scrollbar';
@@ -27,12 +28,17 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
   imageContainer.appendChild(currentImage);
 
   let loadPollTimer: ReturnType<typeof setInterval> | null = null;
+  let loadTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   let loadObserver: MutationObserver | null = null;
 
   function clearLoadPoll(): void {
     if (loadPollTimer) {
       clearInterval(loadPollTimer);
       loadPollTimer = null;
+    }
+    if (loadTimeoutTimer) {
+      clearTimeout(loadTimeoutTimer);
+      loadTimeoutTimer = null;
     }
     if (loadObserver) {
       loadObserver.disconnect();
@@ -85,6 +91,8 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     const wasAutoPlaying = !!store.autoPlayTimer;
     if (wasAutoPlaying) autoPlay.stop();
 
+    let imageErrored = false;
+
     function onImageReady(): void {
       if (store.currentImageIndex !== idx) return;
       const img = store.allImages[idx];
@@ -97,10 +105,47 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
       }
     }
 
-    // Watch for the target image becoming ready via load event
+    function onImageError(): void {
+      imageErrored = true;
+      // If auto-playing, try to skip immediately
+      if (wasAutoPlaying && store.autoPlay) {
+        tryAutoSkip();
+      }
+    }
+
+    function tryAutoSkip(): void {
+      if (store.currentImageIndex !== idx) return;
+      // Check if next image is ready
+      const nextIdx = idx + 1;
+      if (nextIdx < store.allImages.length) {
+        const nextImg = store.allImages[nextIdx];
+        if (nextImg && isImageReady(nextImg)) {
+          clearLoadPoll();
+          store.currentImageIndex = nextIdx;
+          removePlaceholder();
+          currentImage.src = nextImg.src;
+          scrollbar.update();
+          checkAndLoadNextPage();
+          autoPlay.start();
+          return;
+        }
+      }
+      // Next image not ready either — just skip forward and let it poll again
+      if (nextIdx < store.allImages.length || imageErrored) {
+        clearLoadPoll();
+        store.currentImageIndex = nextIdx < store.allImages.length ? nextIdx : idx;
+        updateImage();
+        if (nextIdx < store.allImages.length) {
+          checkAndLoadNextPage();
+        }
+      }
+    }
+
+    // Watch for the target image becoming ready via load/error events
     const img = store.allImages[idx];
     if (img) {
       img.addEventListener('load', onImageReady, { once: true });
+      img.addEventListener('error', onImageError, { once: true });
     }
 
     // Watch for new images appearing in DOM (auto-scroll adding pages)
@@ -116,6 +161,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
           const newImg = store.allImages[idx];
           if (newImg && !img) {
             newImg.addEventListener('load', onImageReady, { once: true });
+            newImg.addEventListener('error', onImageError, { once: true });
             if (isImageReady(newImg)) onImageReady();
           }
         }
@@ -123,11 +169,21 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
       loadObserver.observe(mainBox, { childList: true, subtree: true });
     }
 
-    // Fallback poll at lower frequency for edge cases (e.g. cached images that don't fire load)
+    // Fallback poll for cached images that don't fire load
     loadPollTimer = setInterval(() => {
       if (store.currentImageIndex !== idx) { clearLoadPoll(); return; }
       onImageReady();
     }, 1000);
+
+    // Timeout: if image isn't ready after N seconds and auto-playing, skip forward
+    if (wasAutoPlaying && store.autoPlay) {
+      loadTimeoutTimer = setTimeout(() => {
+        if (store.currentImageIndex !== idx) return;
+        const img = store.allImages[idx];
+        if (img && isImageReady(img)) return; // loaded just in time
+        tryAutoSkip();
+      }, CFG.imageLoadTimeout);
+    }
   }
 
   // Wire up sub-modules (forward declarations resolved via closures)

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -27,6 +27,13 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
   currentImage.className = 'sp-current-image';
   imageContainer.appendChild(currentImage);
 
+  // Error handler for the overlay display image itself
+  currentImage.addEventListener('error', () => {
+    if (!overlay.classList.contains('active')) return;
+    if (!currentImage.src || currentImage.src === location.href) return;
+    showError();
+  });
+
   let loadPollTimer: ReturnType<typeof setInterval> | null = null;
   let loadTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   let loadObserver: MutationObserver | null = null;
@@ -48,6 +55,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
 
   function showPlaceholder(): void {
     currentImage.style.display = 'none';
+    removeErrorUI();
     const existing = imageContainer.querySelector('.sp-placeholder');
     if (existing) existing.remove();
 
@@ -60,12 +68,60 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
   function removePlaceholder(): void {
     const ph = imageContainer.querySelector('.sp-placeholder');
     if (ph) ph.remove();
+    removeErrorUI();
     currentImage.style.display = '';
+  }
+
+  function showError(): void {
+    clearLoadPoll();
+    currentImage.style.display = 'none';
+    const existing = imageContainer.querySelector('.sp-placeholder');
+    if (existing) existing.remove();
+    removeErrorUI();
+
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'sp-error';
+    errorDiv.innerHTML = `<div class="sp-error-text">${store.imageOffset + store.currentImageIndex + 1} / ${store.imageOffset + store.allImages.length}</div><div class="sp-error-msg">Load Failed</div><button class="sp-error-retry">Retry</button>`;
+    const retryBtn = errorDiv.querySelector('.sp-error-retry') as HTMLButtonElement;
+    retryBtn.onclick = () => retryCurrentImage();
+    imageContainer.appendChild(errorDiv);
+  }
+
+  function removeErrorUI(): void {
+    const err = imageContainer.querySelector('.sp-error');
+    if (err) err.remove();
+  }
+
+  function retryCurrentImage(): void {
+    const idx = store.currentImageIndex;
+    // Re-sync DOM images first
+    syncImages();
+    const img = store.allImages[idx];
+    if (img) {
+      // Force re-download by resetting src
+      const oldSrc = img.src;
+      img.removeAttribute('src');
+      img.src = oldSrc;
+    }
+    // Re-enter the normal loading flow
+    updateImage();
+  }
+
+  function syncImages(): void {
+    const freshImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+    if (freshImages.length !== store.allImages.length) {
+      store.allImages = freshImages;
+      scrollbar.update();
+    }
   }
 
   function updateImage(): void {
     clearLoadPoll();
+    removeErrorUI();
     const idx = store.currentImageIndex;
+
+    // Re-sync DOM to catch any replacements (error→retry→new img)
+    syncImages();
     const img = store.allImages[idx];
 
     if (!img) {
@@ -92,9 +148,11 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     if (wasAutoPlaying) autoPlay.stop();
 
     let imageErrored = false;
+    let lastKnownImg = store.allImages[idx];
 
     function onImageReady(): void {
       if (store.currentImageIndex !== idx) return;
+      // Re-check with fresh reference in case DOM was swapped
       const img = store.allImages[idx];
       if (img && isImageReady(img)) {
         clearLoadPoll();
@@ -107,15 +165,18 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
 
     function onImageError(): void {
       imageErrored = true;
-      // If auto-playing, try to skip immediately
       if (wasAutoPlaying && store.autoPlay) {
         tryAutoSkip();
+      } else {
+        // Non-autoplay: show error UI with retry button
+        if (store.currentImageIndex === idx) {
+          showError();
+        }
       }
     }
 
     function tryAutoSkip(): void {
       if (store.currentImageIndex !== idx) return;
-      // Check if next image is ready
       const nextIdx = idx + 1;
       if (nextIdx < store.allImages.length) {
         const nextImg = store.allImages[nextIdx];
@@ -130,7 +191,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
           return;
         }
       }
-      // Next image not ready either — just skip forward and let it poll again
+      // Next image not ready either — skip forward and let it poll again
       if (nextIdx < store.allImages.length || imageErrored) {
         clearLoadPoll();
         store.currentImageIndex = nextIdx < store.allImages.length ? nextIdx : idx;
@@ -142,10 +203,9 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
     }
 
     // Watch for the target image becoming ready via load/error events
-    const img = store.allImages[idx];
-    if (img) {
-      img.addEventListener('load', onImageReady, { once: true });
-      img.addEventListener('error', onImageError, { once: true });
+    if (lastKnownImg) {
+      lastKnownImg.addEventListener('load', onImageReady, { once: true });
+      lastKnownImg.addEventListener('error', onImageError, { once: true });
     }
 
     // Watch for new images appearing in DOM (auto-scroll adding pages)
@@ -157,21 +217,34 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
         if (freshImages.length !== store.allImages.length) {
           store.allImages = freshImages;
           scrollbar.update();
-          // If the target image now exists, listen for its load
-          const newImg = store.allImages[idx];
-          if (newImg && !img) {
-            newImg.addEventListener('load', onImageReady, { once: true });
-            newImg.addEventListener('error', onImageError, { once: true });
-            if (isImageReady(newImg)) onImageReady();
-          }
+        }
+        // Check if the image at idx changed (e.g. error→retry created a new <img>)
+        const currentImg = store.allImages[idx];
+        if (currentImg && currentImg !== lastKnownImg) {
+          lastKnownImg = currentImg;
+          currentImg.addEventListener('load', onImageReady, { once: true });
+          currentImg.addEventListener('error', onImageError, { once: true });
+          if (isImageReady(currentImg)) onImageReady();
         }
       });
       loadObserver.observe(mainBox, { childList: true, subtree: true });
     }
 
-    // Fallback poll for cached images that don't fire load
+    // Fallback poll — also re-syncs DOM references
     loadPollTimer = setInterval(() => {
       if (store.currentImageIndex !== idx) { clearLoadPoll(); return; }
+      // Re-sync in case DOM changed without MutationObserver catching it
+      const freshImages = Array.from(qa('.r-img')) as HTMLImageElement[];
+      if (freshImages.length !== store.allImages.length) {
+        store.allImages = freshImages;
+        scrollbar.update();
+      }
+      const currentImg = store.allImages[idx];
+      if (currentImg && currentImg !== lastKnownImg) {
+        lastKnownImg = currentImg;
+        currentImg.addEventListener('load', onImageReady, { once: true });
+        currentImg.addEventListener('error', onImageError, { once: true });
+      }
       onImageReady();
     }, 1000);
 
@@ -180,7 +253,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
       loadTimeoutTimer = setTimeout(() => {
         if (store.currentImageIndex !== idx) return;
         const img = store.allImages[idx];
-        if (img && isImageReady(img)) return; // loaded just in time
+        if (img && isImageReady(img)) return;
         tryAutoSkip();
       }, CFG.imageLoadTimeout);
     }
@@ -258,6 +331,7 @@ export function createSinglePageOverlay(deps: OverlayDeps): SinglePageModeHandle
 
   function close(): void {
     clearLoadPoll();
+    removeErrorUI();
     autoPlay.stop();
     store.autoPlay = false;
     overlay.classList.remove('active');

--- a/src/ui/single-page/scrollbar.ts
+++ b/src/ui/single-page/scrollbar.ts
@@ -9,6 +9,7 @@ export interface ScrollbarHandle {
 export function createScrollbar(
   onIndexChange: (index: number) => void,
   onScrollToBottom?: () => void,
+  onScrollToTop?: () => void,
 ): ScrollbarHandle {
   const pageIndicator = document.createElement('div');
   pageIndicator.className = 'sp-scrollbar';
@@ -22,7 +23,7 @@ export function createScrollbar(
   pageIndicator.appendChild(scrollbarThumb);
   pageIndicator.appendChild(scrollbarLabel);
 
-  const thumbPanel = createThumbnailPanel(onIndexChange, onScrollToBottom);
+  const thumbPanel = createThumbnailPanel(onIndexChange, onScrollToBottom, onScrollToTop);
   pageIndicator.appendChild(thumbPanel.getElement());
   scrollbarLabel.style.display = 'none';
 
@@ -55,7 +56,7 @@ export function createScrollbar(
 
     scrollbarThumb.style.height = `${thumbHeight}px`;
     scrollbarThumb.style.top = `${thumbTop}px`;
-    scrollbarLabel.textContent = `${store.currentImageIndex + 1} / ${store.allImages.length}`;
+    scrollbarLabel.textContent = `${store.imageOffset + store.currentImageIndex + 1} / ${store.imageOffset + store.allImages.length}`;
     thumbPanel.update();
   }
 

--- a/src/ui/single-page/scrollbar.ts
+++ b/src/ui/single-page/scrollbar.ts
@@ -6,7 +6,10 @@ export interface ScrollbarHandle {
   getElement: () => HTMLElement;
 }
 
-export function createScrollbar(onIndexChange: (index: number) => void): ScrollbarHandle {
+export function createScrollbar(
+  onIndexChange: (index: number) => void,
+  onScrollToBottom?: () => void,
+): ScrollbarHandle {
   const pageIndicator = document.createElement('div');
   pageIndicator.className = 'sp-scrollbar';
 
@@ -19,7 +22,7 @@ export function createScrollbar(onIndexChange: (index: number) => void): Scrollb
   pageIndicator.appendChild(scrollbarThumb);
   pageIndicator.appendChild(scrollbarLabel);
 
-  const thumbPanel = createThumbnailPanel(onIndexChange);
+  const thumbPanel = createThumbnailPanel(onIndexChange, onScrollToBottom);
   pageIndicator.appendChild(thumbPanel.getElement());
   scrollbarLabel.style.display = 'none';
 

--- a/src/ui/single-page/thumbnail-panel.ts
+++ b/src/ui/single-page/thumbnail-panel.ts
@@ -13,6 +13,7 @@ const BUFFER = 3;
 export function createThumbnailPanel(
   onIndexChange: (index: number) => void,
   onScrollToBottom?: () => void,
+  onScrollToTop?: () => void,
 ): ThumbnailPanelHandle {
   const panel = document.createElement('div');
   panel.className = 'sp-thumb-panel';
@@ -81,13 +82,13 @@ export function createThumbnailPanel(
         thumbImg.src = img.src;
       }
       const label = el.querySelector('.sp-thumb-label') as HTMLElement;
-      if (label) label.textContent = String(index + 1);
+      if (label) label.textContent = String(store.imageOffset + index + 1);
     } else {
       if (!el.querySelector('.sp-thumb-ph')) {
         el.innerHTML = '';
         const ph = document.createElement('div');
         ph.className = 'sp-thumb-ph';
-        ph.textContent = String(index + 1);
+        ph.textContent = String(store.imageOffset + index + 1);
         el.appendChild(ph);
       }
     }
@@ -156,7 +157,7 @@ export function createThumbnailPanel(
       lastCenteredIndex = store.currentImageIndex;
     }
     renderVisibleItems();
-    counter.textContent = `${store.currentImageIndex + 1} / ${store.allImages.length}`;
+    counter.textContent = `${store.imageOffset + store.currentImageIndex + 1} / ${store.imageOffset + store.allImages.length}`;
   }
 
   // Wheel: scroll thumbnail list, isolate from reader navigation
@@ -168,6 +169,10 @@ export function createThumbnailPanel(
     // Trigger next page load when scrolled near bottom
     if (onScrollToBottom && scrollOffset >= maxOffset() - ITEM_HEIGHT) {
       onScrollToBottom();
+    }
+    // Trigger prev page load when scrolled near top
+    if (onScrollToTop && scrollOffset <= ITEM_HEIGHT) {
+      onScrollToTop();
     }
   }, { passive: false });
 

--- a/src/ui/single-page/thumbnail-panel.ts
+++ b/src/ui/single-page/thumbnail-panel.ts
@@ -12,6 +12,7 @@ const BUFFER = 3;
 
 export function createThumbnailPanel(
   onIndexChange: (index: number) => void,
+  onScrollToBottom?: () => void,
 ): ThumbnailPanelHandle {
   const panel = document.createElement('div');
   panel.className = 'sp-thumb-panel';
@@ -72,10 +73,15 @@ export function createThumbnailPanel(
         thumbImg = document.createElement('img');
         thumbImg.className = 'sp-thumb-img';
         el.appendChild(thumbImg);
+        const label = document.createElement('span');
+        label.className = 'sp-thumb-label';
+        el.appendChild(label);
       }
       if (thumbImg.src !== img.src) {
         thumbImg.src = img.src;
       }
+      const label = el.querySelector('.sp-thumb-label') as HTMLElement;
+      if (label) label.textContent = String(index + 1);
     } else {
       if (!el.querySelector('.sp-thumb-ph')) {
         el.innerHTML = '';
@@ -159,6 +165,10 @@ export function createThumbnailPanel(
     e.stopPropagation();
     scrollOffset = clamp(scrollOffset + e.deltaY, 0, maxOffset());
     renderVisibleItems();
+    // Trigger next page load when scrolled near bottom
+    if (onScrollToBottom && scrollOffset >= maxOffset() - ITEM_HEIGHT) {
+      onScrollToBottom();
+    }
   }, { passive: false });
 
   // Click: event delegation

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -93,3 +93,10 @@ html.scroll-mode #gdt { display: flex; flex-direction: column; align-items: cent
 .sp-placeholder-pulse { width: 60%; max-width: 500px; height: 60%; background: #181818; border-radius: 8px; animation: sp-pulse 1.5s ease-in-out infinite; }
 .sp-placeholder-text { position: absolute; color: #666; font-family: monospace; font-size: 16px; user-select: none; }
 @keyframes sp-pulse { 0%, 100% { opacity: 0.3; } 50% { opacity: 0.6; } }
+
+/* Single page error state */
+.sp-error { width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; }
+.sp-error-text { color: #666; font-family: monospace; font-size: 16px; -webkit-user-select: none; user-select: none; }
+.sp-error-msg { color: #d44; font-family: sans-serif; font-size: 14px; }
+.sp-error-retry { padding: 8px 24px; background: #333; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 14px; transition: background 0.2s; }
+.sp-error-retry:hover { background: #555; }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,9 +1,9 @@
 /* Theme */
 :root { --accent: #F596AA; --accent-hover: #F7ABBE; }
 
-/* Base styles */
-html, body { background-color: #111 !important; color: #ccc !important; margin: 0; overflow-x: hidden; }
-#gdt { display: flex; flex-direction: column; align-items: center; width: 100%; max-width: 1200px; margin: auto; padding-bottom: 100px; }
+/* Base styles — only applied in scroll mode */
+html.scroll-mode, html.scroll-mode body { background-color: #111 !important; color: #ccc !important; margin: 0; overflow-x: hidden; }
+html.scroll-mode #gdt { display: flex; flex-direction: column; align-items: center; width: 100%; max-width: 1200px; margin: auto; padding-bottom: 100px; }
 
 /* Scroll mode */
 .page-batch { width: 100%; display: flex; flex-direction: column; align-items: center; margin-bottom: 60px; }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -84,6 +84,7 @@ html.scroll-mode #gdt { display: flex; flex-direction: column; align-items: cent
 .sp-thumb-item:hover { border-color: rgba(255,255,255,0.4); }
 .sp-thumb-item.sp-thumb-active { border-color: var(--accent); }
 .sp-thumb-img { width: 100%; height: 100%; object-fit: cover; pointer-events: none; }
+.sp-thumb-label { position: absolute; bottom: 0; right: 0; padding: 1px 5px; background: rgba(0,0,0,0.5); color: rgba(255,255,255,0.6); font-family: monospace; font-size: 11px; border-radius: 4px 0 0 0; pointer-events: none; }
 .sp-thumb-ph { width: 100%; height: 100%; background: #222; display: flex; align-items: center; justify-content: center; color: #555; font-family: monospace; font-size: 13px; -webkit-user-select: none; user-select: none; }
 .sp-thumb-counter { padding: 8px 0; text-align: center; color: #999; font-family: monospace; font-size: 13px; border-top: 1px solid rgba(255,255,255,0.08); -webkit-user-select: none; user-select: none; }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         },
         namespace: 'http://tampermonkey.net/',
         homepageURL: 'https://github.com/Leovikii/e-hentai-plus',
-        version: '2.3.1',
+        version: '2.4.0',
         description: {
           '': 'Infinite scroll & reader mode with image prefetch and floating controls for E-Hentai / ExHentai',
           'zh-CN': '为 E-Hentai / ExHentai 提供无限滚动和阅读模式，支持图片预取与悬浮控制',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         },
         namespace: 'http://tampermonkey.net/',
         homepageURL: 'https://github.com/Leovikii/e-hentai-plus',
-        version: '2.3.0',
+        version: '2.3.1',
         description: {
           '': 'Infinite scroll & reader mode with image prefetch and floating controls for E-Hentai / ExHentai',
           'zh-CN': '为 E-Hentai / ExHentai 提供无限滚动和阅读模式，支持图片预取与悬浮控制',


### PR DESCRIPTION
## 2.4.0

### Performance
- Concurrent request queue (max 3) with 100ms spacing between requests
- Exponential backoff retry (1s → 2s → 4s) with 429/503 rate limit detection
- URL result caching to eliminate duplicate requests between prefetch and page loading

### Reader Mode
- Error state UI with retry button when image fails to load
- Auto-skip: during autoplay, skip past stuck/failed images instead of pausing
- Load previous pages when navigating backward or scrolling up in thumbnail panel
- Thumbnail panel shows page numbers on each thumbnail
- Fixed page numbering when entering from non-first pages (reads `.gpc` image range)

### Bug Fixes
- Fixed `calcTotal` not parsing comma-separated image counts (1,000+)
- Fixed stale DOM references causing reader mode to miss image updates
- Fixed `currentImage` silently failing with no error recovery
- Fixed reader mode entry in non-scroll mode showing wrong images
