### PR TITLE
Set release name; remove hardcoded version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.VERSION }}
-          name: Release ${{ env.VERSION }}
+          name: e-hentai-plus ${{ env.VERSION }}
           body: |
             ### Changes
             ${{ env.CHANGELOG }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         },
         namespace: 'http://tampermonkey.net/',
         homepageURL: 'https://github.com/Leovikii/e-hentai-plus',
-        version: '2.4.1',
+
         description: {
           '': 'Infinite scroll & reader mode with image prefetch and floating controls for E-Hentai / ExHentai',
           'zh-CN': '为 E-Hentai / ExHentai 提供无限滚动和阅读模式，支持图片预取与悬浮控制',


### PR DESCRIPTION
Change CI release name to include the project name and remove the static version in vite.config.ts. The workflow now uses "e-hentai-plus ${{ env.VERSION }}" for release names for clearer GitHub releases, and the hardcoded '2.4.1' version was removed from vite.config.ts to avoid duplication and allow dynamic versioning.