### PR TITLE
Improve image handling, dedupe links, bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hentai-reader",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hentai-reader",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "devDependencies": {
         "@unocss/vite": "^66.0.0",
         "typescript": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hentai-reader",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/sites/18comic/index.ts
+++ b/src/sites/18comic/index.ts
@@ -51,6 +51,7 @@ export const Comic18Adapter: SiteAdapter = {
     const scrambleId = scrambleMatch ? scrambleMatch[1] : (unsafeWindow.scramble_id ? String(unsafeWindow.scramble_id) : '');
 
     const links: PageLink[] = [];
+    const seenUrls = new Set<string>();
     const imgs = doc.querySelectorAll('.scramble-page img[id], .owl-item .center img[id]');
     
     imgs.forEach((img: Element) => {
@@ -62,7 +63,10 @@ export const Comic18Adapter: SiteAdapter = {
         if (scrambleId) urlObj.searchParams.set('18scid', scrambleId);
         
         const viewerUrl = urlObj.toString();
-        links.push({ url: viewerUrl });
+        if (!seenUrls.has(viewerUrl)) {
+          seenUrls.add(viewerUrl);
+          links.push({ url: viewerUrl });
+        }
 
         // We purposefully keep original attributes so native scripts don't crash.
         // However, to prevent the native script from initiating 300 background Canvas decodes
@@ -94,6 +98,7 @@ export const Comic18Adapter: SiteAdapter = {
     const scrambleId = scrambleMatch ? scrambleMatch[1] : '';
 
     const links: PageLink[] = [];
+    const seenUrls = new Set<string>();
     const imgs = doc.querySelectorAll('.scramble-page img[id], .owl-item .center img[id]');
     
     imgs.forEach((img: Element) => {
@@ -102,7 +107,11 @@ export const Comic18Adapter: SiteAdapter = {
         const urlObj = new URL(imgUrl, window.location.href);
         if (aid) urlObj.searchParams.set('18aid', aid);
         if (scrambleId) urlObj.searchParams.set('18scid', scrambleId);
-        links.push({ url: urlObj.toString() });
+        const viewerUrl = urlObj.toString();
+        if (!seenUrls.has(viewerUrl)) {
+          seenUrls.add(viewerUrl);
+          links.push({ url: viewerUrl });
+        }
       }
     });
 
@@ -221,7 +230,11 @@ export const Comic18Adapter: SiteAdapter = {
   },
 
   hideOriginalElements: () => {
-    // Restore native headers, only hide scramble if needed (but we don't hide scramble)
+    const scramblePages = Array.from(document.querySelectorAll('.scramble-page'));
+    for (let i = 1; i < scramblePages.length; i++) {
+      scramblePages[i].remove();
+    }
+    document.querySelectorAll('.owl-carousel').forEach(el => el.remove());
   }
 };
 

--- a/src/sites/4khd/index.ts
+++ b/src/sites/4khd/index.ts
@@ -7,12 +7,12 @@ const parser = new DOMParser();
 function extract4KHDImages(doc: Document): PageLink[] {
   const images = Array.from(qa('figure.wp-block-image img, #basicExample img, .entry-content p img', doc));
   return images.map(img => {
-    let src = (img as HTMLImageElement).src;
+    let src = img.getAttribute('data-src') || img.getAttribute('data-lazy-src') || (img as HTMLImageElement).src;
     
     let thumb = src;
     thumb = thumb.replace(/i\d\.wp\.com\//, '');
     thumb = thumb.replace('pic.4khd.com', 'img.4khd.com');
-    thumb = thumb.replace(/\?.+$/, '');
+    // Do not strip query parameters for thumbnails to preserve server-side resizing
     thumb = thumb.replace(/\/w\d+-rw\//, '/w300-h300-rw/');
 
     src = src.replace(/i\d\.wp\.com\//, '');

--- a/src/ui/single-page/navigation.ts
+++ b/src/ui/single-page/navigation.ts
@@ -19,6 +19,15 @@ export function setupNavigation(deps: NavigationDeps): {
     return document.querySelectorAll('.r-ph').length > 0;
   }
 
+  function isCurrentImageLoading(): boolean {
+    const img = store.allImages[store.currentImageIndex];
+    if (!img) return true;
+    if (img.classList.contains('r-ph') || img.classList.contains('loading') || img.classList.contains('error')) return true;
+    const htmlImg = img as HTMLImageElement;
+    if (htmlImg.tagName === 'IMG' && (!htmlImg.complete || htmlImg.naturalWidth === 0)) return true;
+    return false;
+  }
+
   function syncAllImages(): void {
     const freshImages = Array.from(qa('.r-img')) as HTMLImageElement[];
     if (freshImages.length !== store.allImages.length) {
@@ -71,14 +80,17 @@ export function setupNavigation(deps: NavigationDeps): {
 
     const threshold = 70;
     const now = Date.now();
+    const isLoading = isCurrentImageLoading();
+    // Use 600ms if loading to wait for image, otherwise 60ms to allow rapid scrolling
+    const cooldown = isLoading ? 600 : 60;
     
-    if (Math.abs(accumulatedDelta) >= threshold && (now - lastFlipTime) >= 40) {
+    if (Math.abs(accumulatedDelta) >= threshold && (now - lastFlipTime) >= cooldown) {
       if (accumulatedDelta > 0) {
         nextImage();
       } else {
         previousImage();
       }
-      accumulatedDelta = accumulatedDelta > 0 ? accumulatedDelta - threshold : accumulatedDelta + threshold;
+      accumulatedDelta = 0;
       lastFlipTime = now;
     }
 

--- a/src/ui/single-page/overlay.ts
+++ b/src/ui/single-page/overlay.ts
@@ -146,13 +146,12 @@ export function createSinglePageOverlay(deps: SinglePageOverlayDeps): SinglePage
       const currentImg = store.allImages[store.currentImageIndex];
       if (!currentImg) return;
 
-      if (currentImg.classList.contains('r-ph')) {
-        loadPlaceholderImage(currentImg as HTMLElement);
-      }
-
-      const nextImg = store.allImages[store.currentImageIndex + 1];
-      if (nextImg && nextImg.classList.contains('r-ph')) {
-        loadPlaceholderImage(nextImg as HTMLElement);
+      // Preload current and next 3 images
+      for (let i = 0; i <= 3; i++) {
+        const targetImg = store.allImages[store.currentImageIndex + i];
+        if (targetImg && targetImg.classList.contains('r-ph')) {
+          loadPlaceholderImage(targetImg as HTMLElement);
+        }
       }
 
       if (!isImageReady(currentImg as HTMLImageElement)) {

--- a/src/ui/single-page/sidebar.ts
+++ b/src/ui/single-page/sidebar.ts
@@ -180,11 +180,18 @@ export function createSidebar(
         const tempImg = new Image();
         tempImg.onload = () => {
           if (thumbCanvas!.dataset.src === thumbSrc) {
-            thumbCanvas!.width = tempImg.naturalWidth;
-            thumbCanvas!.height = tempImg.naturalHeight;
+            const MAX_W = 300;
+            let w = tempImg.naturalWidth;
+            let h = tempImg.naturalHeight;
+            if (w > MAX_W) {
+              h = (h * MAX_W) / w;
+              w = MAX_W;
+            }
+            thumbCanvas!.width = w;
+            thumbCanvas!.height = h;
             const ctx = thumbCanvas!.getContext('2d');
             if (ctx) {
-              ctx.drawImage(tempImg, 0, 0);
+              ctx.drawImage(tempImg, 0, 0, w, h);
             }
           }
         };


### PR DESCRIPTION
Bump package version to 3.0.2. Deduplicate 18comic image links by tracking seen URLs and clean up original scramble/owl elements. For 4khd prefer data-src/data-lazy-src when available and preserve thumbnail query params (avoid stripping) while normalizing host/path. Improve single-page navigation by detecting current image loading state, using adaptive cooldowns, and resetting accumulated delta. Expand overlay preloading to current + next 3 images. Scale sidebar thumbnail canvas to max width 300 while preserving aspect ratio. Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>